### PR TITLE
Support Win and Mac NL

### DIFF
--- a/src/main/java/org/linuxstuff/mojo/licensing/model/LicensingReport.java
+++ b/src/main/java/org/linuxstuff/mojo/licensing/model/LicensingReport.java
@@ -181,14 +181,14 @@ public class LicensingReport {
         return textResource;
     }
 
-    private void writeToFile( File fromFile, PrintWriter writer )
+    static void writeToFile( File fromFile, PrintWriter writer )
             throws IOException
     {
         if (fromFile  != null)
         {
-            String[] lines = FileUtils.fileRead( fromFile, FILE_ENCODING ).split( "\n" );
+            String[] lines = FileUtils.fileRead(fromFile, FILE_ENCODING).split("\r\n|\r|\n");
             for (String line : lines) {
-                writer.println( line );
+                writer.println(line);
             }
             writer.println();
         }

--- a/src/test/java/org/linuxstuff/mojo/licensing/model/LicensingReportTest.java
+++ b/src/test/java/org/linuxstuff/mojo/licensing/model/LicensingReportTest.java
@@ -1,0 +1,77 @@
+package org.linuxstuff.mojo.licensing.model;
+
+import org.codehaus.plexus.util.IOUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@RunWith(Parameterized.class)
+public class LicensingReportTest {
+
+
+    @Parameterized.Parameters
+    public static Iterable<Object[]> data() {
+
+        final List<Object[]> result = new ArrayList<Object[]>();
+
+        List<String> nls = Arrays.asList("\r", "\n", "\r\n");
+
+        for (String aNL : nls) {
+            result.add(new Object[]{"aaa" + aNL + "bbb", aNL});
+
+        }
+
+        return result;
+    }
+
+    private final String input;
+    private final String nl;
+    private String originalNL;
+
+    public LicensingReportTest(String input, String nl) {
+        this.input = input;
+        this.nl = nl;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        originalNL = System.getProperty("line.separator");
+    }
+
+    @Test
+    public void testWriteToFile() throws Exception {
+
+        File file = File.createTempFile("test", ".txt");
+        file.deleteOnExit();
+
+        FileWriter fileWriter = new FileWriter(file);
+        IOUtil.copy(input, fileWriter);
+        IOUtil.close(fileWriter);
+
+        StringWriter stringWriter = new StringWriter();
+
+        System.setProperty("line.separator", nl);
+        LicensingReport.writeToFile(file, new PrintWriter(stringWriter));
+        String output = stringWriter.toString();
+
+        String expected = input + nl + nl;
+        assertEquals(expected, output);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.setProperty("line.separator", originalNL);
+    }
+}


### PR DESCRIPTION
Hi, 

when I trying to build Neo4J on Win8 licensing-maven-plugin fails because of incompatible NLs in licence files. This patch supports Win and Mac NLs. You can merge it if you like it. 

Ivos

```
[ERROR] Failed to execute goal org.neo4j.build.plugins:licensing-maven-plugin:1.7.5:check (list-all-licenses) on project licensecheck-config: Generated file differs from the existing file.
[ERROR] Generated: C:\git\neo4j\community\licensecheck-config\target\licensecheck-config-2.2-SNAPSHOT-NOTICE.txt
[ERROR] Existing: C:\git\neo4j\community\licensecheck-config\target\..\NOTICE.txt
```
