### PR TITLE
Ignore EOL characters during license file comparisons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 *~
 #*#
 *.swp
+.idea
 .classpath
 .project
 .settings
+*.iml
 target

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<groupId>org.neo4j.build.plugins</groupId>
 	<artifactId>licensing-maven-plugin</artifactId>
 	<packaging>maven-plugin</packaging>
-	<version>1.7.5</version>
+	<version>1.7.6-SNAPSHOT</version>
 	<name>Licensing Maven Mojo</name>
 	<url>https://github.com/neo4j/licensing-maven-plugin</url>
 	<description>Forked from  http://github.com/idcmp/licensing-maven-plugin</description>
@@ -85,9 +85,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.3.2</version>
 				<configuration>
-					<!-- http://maven.apache.org/plugins/maven-compiler-plugin/ -->
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 
@@ -134,6 +133,13 @@
 			<artifactId>commons-lang</artifactId>
 			<version>2.6</version>
 		</dependency>
+
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.6</version>
+		</dependency>
+
 
 		<!-- maven -->
 		<dependency>

--- a/src/main/java/org/linuxstuff/mojo/licensing/CheckMojo.java
+++ b/src/main/java/org/linuxstuff/mojo/licensing/CheckMojo.java
@@ -1,16 +1,16 @@
 package org.linuxstuff.mojo.licensing;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.linuxstuff.mojo.licensing.model.ArtifactWithLicenses;
+import org.linuxstuff.mojo.licensing.model.LicensingReport;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Set;
-
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.util.FileUtils;
-import org.linuxstuff.mojo.licensing.model.ArtifactWithLicenses;
-import org.linuxstuff.mojo.licensing.model.LicensingReport;
 
 /**
  * Determine licensing information of all dependencies. This is generally
@@ -150,15 +150,14 @@ public class CheckMojo extends AbstractLicensingMojo {
 
 	}
 
-    private void compareToExistingFile( File file, String existingFileName )
-            throws MojoExecutionException
+    void compareToExistingFile( File file, String existingFileName ) throws MojoExecutionException
     {
         if ( existingFileName != null )
         {
             File existingFile = FileUtils.getFile( existingFileName );
             try
             {
-                if ( !FileUtils.contentEquals( file, existingFile ) )
+                if ( !FileUtils.contentEqualsIgnoreEOL( file, existingFile, null ) )
                 {
                     generatedAndExistingDiffer( file, existingFile );
                 }
@@ -183,7 +182,7 @@ public class CheckMojo extends AbstractLicensingMojo {
             try
             {
                 getLog().info( "Replacing " + existingFile );
-                FileUtils.rename( file, existingFile );
+                FileUtils.moveFile( file, existingFile );
             }
             catch ( IOException e )
             {

--- a/src/main/java/org/linuxstuff/mojo/licensing/model/LicensingReport.java
+++ b/src/main/java/org/linuxstuff/mojo/licensing/model/LicensingReport.java
@@ -1,9 +1,21 @@
 package org.linuxstuff.mojo.licensing.model;
 
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
+import com.thoughtworks.xstream.io.xml.StaxDriver;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.codehaus.plexus.resource.ResourceManager;
+import org.codehaus.plexus.resource.loader.FileResourceCreationException;
+import org.codehaus.plexus.resource.loader.ResourceNotFoundException;
+import org.codehaus.plexus.util.FileUtils;
+import org.linuxstuff.mojo.licensing.FileUtil;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -12,24 +24,12 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
-import org.apache.maven.plugin.MojoExecutionException;
-import org.codehaus.plexus.resource.ResourceManager;
-import org.codehaus.plexus.resource.loader.FileResourceCreationException;
-import org.codehaus.plexus.resource.loader.ResourceNotFoundException;
-import org.codehaus.plexus.util.FileUtils;
-import org.linuxstuff.mojo.licensing.FileUtil;
-
-import com.thoughtworks.xstream.XStream;
-import com.thoughtworks.xstream.annotations.XStreamAlias;
-import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
-import com.thoughtworks.xstream.io.xml.StaxDriver;
-
 @XStreamAlias("licensing")
 public class LicensingReport {
 
 	private static final String LINE = "------------------------------------------------------------------------------";
 
-    private static final String FILE_ENCODING = "UTF-8";
+    public static final String FILE_ENCODING = StandardCharsets.UTF_8.name();
 
     @XStreamAlias("disliked-licenses")
 	@XStreamAsAttribute


### PR DESCRIPTION
Ignore EOL to allow Windows and Unix license files to be comparable by default without any options.