### PR TITLE
Fix license and notice file generation on windows by just using template

### DIFF
--- a/src/main/java/org/linuxstuff/mojo/licensing/CheckMojo.java
+++ b/src/main/java/org/linuxstuff/mojo/licensing/CheckMojo.java
@@ -182,7 +182,7 @@ public class CheckMojo extends AbstractLicensingMojo {
             try
             {
                 getLog().info( "Replacing " + existingFile );
-                FileUtils.moveFile( file, existingFile );
+                org.codehaus.plexus.util.FileUtils.rename( file, existingFile );
             }
             catch ( IOException e )
             {

--- a/src/main/java/org/linuxstuff/mojo/licensing/model/LicensingReport.java
+++ b/src/main/java/org/linuxstuff/mojo/licensing/model/LicensingReport.java
@@ -186,10 +186,7 @@ public class LicensingReport {
     {
         if (fromFile  != null)
         {
-            String[] lines = FileUtils.fileRead( fromFile, FILE_ENCODING ).split( "\n" );
-            for (String line : lines) {
-                writer.println( line );
-            }
+			writer.println( FileUtils.fileRead( fromFile, FILE_ENCODING ) );
             writer.println();
         }
     }


### PR DESCRIPTION
file and not trying to split and write lines all over again.
Fix accidentally broken license file overriding.