### PR TITLE
Fix comparison of coalesced licenses names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,5 +185,12 @@
 			<version>1.4.2</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>2.19.0</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 </project>

--- a/src/main/java/org/linuxstuff/mojo/licensing/model/LicensingRequirements.java
+++ b/src/main/java/org/linuxstuff/mojo/licensing/model/LicensingRequirements.java
@@ -1,10 +1,10 @@
 package org.linuxstuff.mojo.licensing.model;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+import java.util.HashSet;
+import java.util.Set;
 
 @XStreamAlias("licensing-requirements")
 public class LicensingRequirements {
@@ -78,11 +78,13 @@ public class LicensingRequirements {
 	
 	public String getCorrectLicenseName(String name) {
 		for (CoalescedLicense coalesced : coalescedLicenses) {
-			if (coalesced.getFinalName().equalsIgnoreCase(name.trim()))
-				return name;
+			if (coalesced.getFinalName().equalsIgnoreCase(name.trim())) {
+				return coalesced.getFinalName();
+			}
 			for (String otherName : coalesced.getOtherNames()) {
-				if (otherName.equalsIgnoreCase(name.trim()))
+				if (otherName.equalsIgnoreCase(name.trim())) {
 					return coalesced.getFinalName();
+				}
 			}
 		}
 

--- a/src/test/java/org/linuxstuff/mojo/licensing/CheckMojoTest.java
+++ b/src/test/java/org/linuxstuff/mojo/licensing/CheckMojoTest.java
@@ -1,0 +1,58 @@
+package org.linuxstuff.mojo.licensing;
+
+import com.google.common.collect.Sets;
+import org.apache.maven.model.License;
+import org.apache.maven.project.MavenProject;
+import org.junit.Test;
+import org.linuxstuff.mojo.licensing.model.CoalescedLicense;
+import org.linuxstuff.mojo.licensing.model.LicensingReport;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.TreeMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+public class CheckMojoTest extends AbstractLicensingTest
+{
+
+    @Test
+    public void artifactWithSingleCoalescingLicenseIsValid()
+    {
+        String mitLicense = "MIT License";
+        String anotherMitLicense = "MIT license";
+        License license = prepareLisence( anotherMitLicense );
+        DependenciesTool dependenciesTool = prepareDependencyTool( license );
+
+        CheckMojo checkMojo = new CheckMojo();
+        checkMojo.dependenciesTool = dependenciesTool;
+        checkMojo.licensingRequirements.addLikedLicense( mitLicense );
+        checkMojo.licensingRequirements.addCoalescedLicense( new CoalescedLicense( mitLicense, Sets.newHashSet( anotherMitLicense ) ) );
+        checkMojo.includeOnlyLikedInReport = true;
+
+        LicensingReport licensingReport = checkMojo.generateReport( mavenProject );
+        assertTrue( licensingReport.getDislikedArtifacts().isEmpty() );
+        assertEquals( 1, licensingReport.getLicensedArtifacts().size() );
+    }
+
+    private static License prepareLisence( String anotherMitLicense )
+    {
+        License license = new License();
+        license.setName( anotherMitLicense );
+        return license;
+    }
+
+    private static DependenciesTool prepareDependencyTool( License license )
+    {
+        TreeMap<String,MavenProject> projectMap = new TreeMap<>();
+        MavenProject dependencyProject = new MavenProject();
+        dependencyProject.setLicenses( Collections.singletonList( license ) );
+        projectMap.put( "a", dependencyProject );
+        DependenciesTool dependenciesTool = Mockito.mock( DependenciesTool.class );
+        when( dependenciesTool.loadProjectDependencies( any(), any(), any(), any(), any() ) ).thenReturn( projectMap );
+        return dependenciesTool;
+    }
+}


### PR DESCRIPTION
Previously ignore case comparison of license name was used to check if
licenses were the same. But as result of that comparison incorrect
license name was returned if names were matched.
That was causing rejects of artifacts with valid licenses.