### PR TITLE
Fix XStream error that breaks neo4j (3.5) licensing/licensing-require…

### DIFF
--- a/src/main/java/org/linuxstuff/mojo/licensing/model/CoalescedLicense.java
+++ b/src/main/java/org/linuxstuff/mojo/licensing/model/CoalescedLicense.java
@@ -16,6 +16,10 @@ public class CoalescedLicense {
 	@XStreamImplicit(itemFieldName = "aka")
 	private Set<String> otherNames;
 
+	public CoalescedLicense() {
+		/* Hello XStream */
+	}
+
 	public CoalescedLicense(String finalName, Set<String> otherNames) {
 		this.finalName = finalName;
 		this.otherNames = otherNames;

--- a/src/main/java/org/linuxstuff/mojo/licensing/model/DualLicense.java
+++ b/src/main/java/org/linuxstuff/mojo/licensing/model/DualLicense.java
@@ -16,6 +16,10 @@ public class DualLicense {
 	@XStreamImplicit(itemFieldName = "option")
 	private Set<String> optionalLicenses;
 
+	public DualLicense() {
+		/* Hello XStream */
+	}
+
 	public DualLicense(String finalName, Set<String> optionalLicenses) {
 		this.finalName = finalName;
 		this.optionalLicenses = optionalLicenses;


### PR DESCRIPTION
…ments-base.xml

com.thoughtworks.xstream.converters.reflection.ObjectAccessException: Cannot construct org.linuxstuff.mojo.licensing.model.CoalescedLicense as it does not have a no-args constructor
at com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider.newInstance(PureJavaReflectionProvider.java:71)

When I try building neo4j 3.5 using
```
$ java -version
openjdk version "1.8.0_242"
OpenJDK Runtime Environment (build 1.8.0_242-b08)
Eclipse OpenJ9 VM (build openj9-0.18.1, JRE 1.8.0 Mac OS X amd64-64-Bit Compressed References 20200122_439 (JIT enabled, AOT enabled)
OpenJ9   - 51a5857d2
OMR      - 7a1b0239a
JCL      - 8cf8a30581 based on jdk8u242-b08)
```
I hit: eclipse/openj9#2555

The analysis is here: https://github.com/eclipse/openj9/issues/2555#issuecomment-441296451

And simply adding these two constructors results in things working. While I am interested in understanding why the Reference Implementation doesn't trip over the same logic, I think it'd be nice if everyone else was able to use this project w/o having to wait for someone to figure it out.

That said, if someone can help identify why non openj9 users don't trip over this, I'd be really interested in hearing the answer.

