### PR TITLE
Revert source and target JDK version to 8.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.0</version>
 				<configuration>
-					<source>11</source>
-					<target>11</target>
+					<source>8</source>
+					<target>8</target>
 				</configuration>
 			</plugin>
 

--- a/src/test/java/org/linuxstuff/mojo/licensing/ReadLicensingRequirementsTest.java
+++ b/src/test/java/org/linuxstuff/mojo/licensing/ReadLicensingRequirementsTest.java
@@ -1,0 +1,40 @@
+package org.linuxstuff.mojo.licensing;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.linuxstuff.mojo.licensing.model.ArtifactWithLicenses;
+import org.linuxstuff.mojo.licensing.model.CoalescedLicense;
+import org.linuxstuff.mojo.licensing.model.DualLicense;
+import org.linuxstuff.mojo.licensing.model.LicensingRequirements;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.io.xml.StaxDriver;
+
+public class ReadLicensingRequirementsTest {
+
+	@Test
+	public void xstreamShouldBeAbleToReadTheRequirementsFile() {
+		XStream xstream = new XStream(new StaxDriver());
+
+		xstream.processAnnotations(LicensingRequirements.class);
+		xstream.processAnnotations(ArtifactWithLicenses.class);
+		xstream.processAnnotations(CoalescedLicense.class);
+
+		LicensingRequirements licensingRequirements = (LicensingRequirements) xstream
+			.fromXML(this.getClass().getResourceAsStream("/licensing-requirements-example.xml"));
+
+		Assert.assertEquals(1, licensingRequirements.getDualLicenses().size());
+		DualLicense dualLicense = licensingRequirements.getDualLicenses().iterator().next();
+		Assert.assertEquals(
+			"Common Development and Distribution License Version 1.1 and GNU General Public License, version 2 with the Classpath Exception",
+			dualLicense.getFinalName());
+		Assert.assertEquals(2, dualLicense.getOptionalLicenses().size());
+
+		Assert.assertEquals(1, licensingRequirements.getCoalescedLicenses().size());
+		CoalescedLicense coalescedLicense = licensingRequirements.getCoalescedLicenses().iterator().next();
+		Assert.assertEquals(
+			"GNU Affero General Public License, Version 3",
+			coalescedLicense.getFinalName());
+		Assert.assertEquals(1, coalescedLicense.getOtherNames().size());
+	}
+}

--- a/src/test/resources/licensing-requirements-example.xml
+++ b/src/test/resources/licensing-requirements-example.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<licensing-requirements>
+	<coalesced-licenses>
+		<license name="GNU Affero General Public License, Version 3">
+			<aka>AGPL3</aka>
+		</license>
+	</coalesced-licenses>
+	<dual-licenses>
+		<dual-license
+				name="Common Development and Distribution License Version 1.1 and GNU General Public License, version 2 with the Classpath Exception">
+			<option>Common Development and Distribution License Version 1.1</option>
+			<option>GNU General Public License, version 2 with the Classpath Exception</option>
+		</dual-license>
+	</dual-licenses>
+
+</licensing-requirements>


### PR DESCRIPTION
I would like to revert the source and target version of this plugin to JDK 8. There is no need to target 11 only here. 

If we do this, than the good fixes in regards of XStream can be used in Neo4j 3.5 as well and would fix this annoying issue https://github.com/neo4j/neo4j/issues/12256.

1.7.8 cannot be used with 3.5 as 3.5 must be compiled with JDK 8.