### PR TITLE
Update dependencies and bump plugin version to 1.7.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.4</version>
+						<version>1.6</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>
@@ -83,7 +83,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.0</version>
+				<version>3.8.1</version>
 				<configuration>
 					<source>8</source>
 					<target>8</target>
@@ -93,7 +93,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.0.1</version>
+				<version>3.2.0</version>
 				<configuration>
 					<skip>true</skip>
 				</configuration>
@@ -102,7 +102,7 @@
 			<plugin>
 				<groupId>org.codehaus.plexus</groupId>
 				<artifactId>plexus-component-metadata</artifactId>
-				<version>2.0.0</version>
+				<version>2.1.0</version>
 				<executions>
 					<execution>
 						<goals>
@@ -114,7 +114,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-plugin-plugin</artifactId>
-				<version>2.9</version>
+				<version>3.6.0</version>
 				<executions>
 					<execution>
 						<id>generated-helpmojo</id>
@@ -133,20 +133,20 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.10</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-			<version>2.6</version>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.12.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.6</version>
+			<version>2.8.0</version>
 		</dependency>
 
 
@@ -176,19 +176,19 @@
 		<dependency>
 			<groupId>org.codehaus.plexus</groupId>
 			<artifactId>plexus-resources</artifactId>
-			<version>1.0-alpha-7</version>
+			<version>1.1.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.thoughtworks.xstream</groupId>
 			<artifactId>xstream</artifactId>
-			<version>1.4.11.1</version>
+			<version>1.4.16</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>2.19.0</version>
+			<version>3.9.0</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/main/java/org/linuxstuff/mojo/licensing/DefaultDependenciesTool.java
+++ b/src/main/java/org/linuxstuff/mojo/licensing/DefaultDependenciesTool.java
@@ -32,7 +32,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.project.MavenProject;


### PR DESCRIPTION
Bump dependencies to allow plugin execution on java [16, )
Some warnings appear now about legacy syntax usage, ignoring those for now since do not have enough trust in used test suite.
Bump dependencies:
maven-gpg-plugin 1.4 -> 1.6
maven-compiler-plugin 3.8.0 -> 3.8.1
maven-javadoc-plugin 3.0.1 -> 3.2.0
plexus-component-metadata 2.0.0 -> 2.1.0
maven-plugin-plugin 2.9 -> 3.6.0
junit 4.10 -> 4.13.2
commons-lang 2.6 -> commons-lang3 3.12.0
commons-io 2.6 -> 2.8.0
plexus-resources 1.0-alpha-7 -> 1.1.0
xstream 1.4.11.1 -> 1.4.16
mockito-core 2.19.0 -> 3.9.0