### PR TITLE
update vulnerable dependency: com.thoughtworks.xstream:xstream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
 		<dependency>
 			<groupId>com.thoughtworks.xstream</groupId>
 			<artifactId>xstream</artifactId>
-			<version>1.4.16</version>
+			<version>1.4.19</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION

Hi! We spot a vulnerable dependency in your project, which might threaten your software. We also found another project that uses the same vulnerable dependency in a similar way as you did, and they have upgraded the dependency. We, thus, believe that your project is highly possible to be affected by this vulnerability similarly. The following shows the detailed information. 

## Vulnerability description
+ CVE: **CVE-2021-39154**
+ Vulnerable dependency: **com.thoughtworks.xstream:xstream**
+ Vulnerable function: **com.thoughtworks.xstream.XStream:unmarshal(com.thoughtworks.xstream.io.HierarchicalStreamReader,java.lang.Object,com.thoughtworks.xstream.converters.DataHolder)**
+ Invocation Path: 
```java
org.linuxstuff.mojo.licensing.AbstractLicensingMojo:readLicensingRequirements()
 ⬇️ 
com.thoughtworks.xstream.XStream:fromXML(java.io.InputStream)
 ⬇️ 
...
 ⬇️ 
com.thoughtworks.xstream.XStream:unmarshal(com.thoughtworks.xstream.io.HierarchicalStreamReader,java.lang.Object,com.thoughtworks.xstream.converters.DataHolder)
```

## Upgrade example
Another project also used the same dependency with a similar invocation path, and they have taken actions to resolve this issue.
+ Project: https://github.com/kiegroup/kogito-runtimes
+ Action commit:https://github.com/kiegroup/kogito-runtimes/commit/be534eb1bf87d95083fc9caa90b680b40f42c749
+ Invocation Path:
```java
org.drools.compiler.kproject.models.KieModuleMarshaller:fromXML(java.io.InputStream)
 ⬇️ 
com.thoughtworks.xstream.XStream:fromXML(java.io.InputStream)
 ⬇️ 
...
 ⬇️ 
com.thoughtworks.xstream.XStream:unmarshal(com.thoughtworks.xstream.io.HierarchicalStreamReader,java.lang.Object,com.thoughtworks.xstream.converters.DataHolder)
```

Therefore, you might also need to upgrade this dependency. Hope this can help you! 😄
