### PR TITLE
update xstream and add classes to allowlist

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
 		<dependency>
 			<groupId>com.thoughtworks.xstream</groupId>
 			<artifactId>xstream</artifactId>
-			<version>1.4.16</version>
+			<version>1.4.21</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/org/linuxstuff/mojo/licensing/AbstractLicensingMojo.java
+++ b/src/main/java/org/linuxstuff/mojo/licensing/AbstractLicensingMojo.java
@@ -16,6 +16,8 @@ import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.resource.ResourceManager;
 import org.linuxstuff.mojo.licensing.model.ArtifactWithLicenses;
 import org.linuxstuff.mojo.licensing.model.CoalescedLicense;
+import org.linuxstuff.mojo.licensing.model.DualLicense;
+import org.linuxstuff.mojo.licensing.model.LicensingReport;
 import org.linuxstuff.mojo.licensing.model.LicensingRequirements;
 
 import com.thoughtworks.xstream.XStream;
@@ -201,6 +203,14 @@ abstract public class AbstractLicensingMojo extends AbstractMojo implements Mave
 	protected void readLicensingRequirements() throws MojoExecutionException {
 
 		XStream xstream = new XStream(new StaxDriver());
+
+		xstream.allowTypes(new Class[] {
+                ArtifactWithLicenses.class,
+                CoalescedLicense.class,
+                DualLicense.class,
+                LicensingReport.class,
+                LicensingRequirements.class
+		});
 
 		xstream.processAnnotations(LicensingRequirements.class);
 		xstream.processAnnotations(ArtifactWithLicenses.class);

--- a/src/main/java/org/linuxstuff/mojo/licensing/CollectReportsMojo.java
+++ b/src/main/java/org/linuxstuff/mojo/licensing/CollectReportsMojo.java
@@ -8,7 +8,10 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
 import org.linuxstuff.mojo.licensing.model.ArtifactWithLicenses;
+import org.linuxstuff.mojo.licensing.model.CoalescedLicense;
+import org.linuxstuff.mojo.licensing.model.DualLicense;
 import org.linuxstuff.mojo.licensing.model.LicensingReport;
+import org.linuxstuff.mojo.licensing.model.LicensingRequirements;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.xml.StaxDriver;
@@ -48,6 +51,13 @@ public class CollectReportsMojo extends AbstractLicensingMojo {
 		report = new LicensingReport();
 
 		XStream xstream = new XStream(new StaxDriver());
+		xstream.allowTypes(new Class[] {
+                ArtifactWithLicenses.class,
+                CoalescedLicense.class,
+                DualLicense.class,
+                LicensingReport.class,
+                LicensingRequirements.class
+		});
 		xstream.processAnnotations(ArtifactWithLicenses.class);
 		xstream.processAnnotations(LicensingReport.class);
 

--- a/src/test/java/org/linuxstuff/mojo/licensing/ReadLicensingRequirementsTest.java
+++ b/src/test/java/org/linuxstuff/mojo/licensing/ReadLicensingRequirementsTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.linuxstuff.mojo.licensing.model.ArtifactWithLicenses;
 import org.linuxstuff.mojo.licensing.model.CoalescedLicense;
 import org.linuxstuff.mojo.licensing.model.DualLicense;
+import org.linuxstuff.mojo.licensing.model.LicensingReport;
 import org.linuxstuff.mojo.licensing.model.LicensingRequirements;
 
 import com.thoughtworks.xstream.XStream;
@@ -15,7 +16,13 @@ public class ReadLicensingRequirementsTest {
 	@Test
 	public void xstreamShouldBeAbleToReadTheRequirementsFile() {
 		XStream xstream = new XStream(new StaxDriver());
-
+		xstream.allowTypes(new Class[] {
+                ArtifactWithLicenses.class,
+                CoalescedLicense.class,
+                DualLicense.class,
+                LicensingReport.class,
+                LicensingRequirements.class
+		});
 		xstream.processAnnotations(LicensingRequirements.class);
 		xstream.processAnnotations(ArtifactWithLicenses.class);
 		xstream.processAnnotations(CoalescedLicense.class);


### PR DESCRIPTION
Update to newer version of xstream and add `ArtifactWithLicenses.class, CoalescedLicense.class, DualLicense.class, LicensingReport.class, LicensingRequirements.class` to the allowlist of allowed types. 

This should get rid of the warning `Security framework of XStream not explicitly initialized, using predefined black list on your own risk.` when using this plugin.

Tested this by using `1.7.12-SNAPSHOT` in the mono repo.